### PR TITLE
Removing the fetch depth.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,8 +21,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Set up JDK 11
       uses: actions/setup-java@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,6 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
 
     - name: Set up JDK 11
       uses: actions/setup-java@v1


### PR DESCRIPTION
Associated with #104 

Because Arduino copies the C++ files to a separate folder for the build process, the history on these files will never be able to be determined.